### PR TITLE
Update utox-9999.ebuild

### DIFF
--- a/net-im/utox/utox-9999.ebuild
+++ b/net-im/utox/utox-9999.ebuild
@@ -27,5 +27,5 @@ src_configure() {
 }
 
 src_install() {
-	emake DESTDIR="${D}/usr" install
+	emake DESTDIR="${D}" PREFIX="/usr" install
 }


### PR DESCRIPTION
The Makefile installation paths were fixed in https://github.com/notsecure/uTox/commit/11f23792ee573482750e2ce1a6090a8c89e065ac#diff-b67911656ef5d18c4ae36cb6741b7965
