### PR TITLE
Place Racket wrapper in separate ebuild

### DIFF
--- a/dev-scheme/libtoxcore-racket/libtoxcore-racket.ebuild
+++ b/dev-scheme/libtoxcore-racket/libtoxcore-racket.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+inherit git-2
+
+DESCRIPTION="Racket bindings for the Tox library."
+HOMEPAGE="https://github.com/lehitoskin/libtoxcore-racket"
+EGIT_REPO_URI="git://github.com/lehitoskin/libtoxcore-racket
+	https://github.com/lehitoskin/libtoxcore-racket"
+LICENSE="GPL-3"
+SLOT="0"
+
+RDEPEND=">=dev-scheme/racket-6.0.1[X]"
+
+src_compile() {
+	raco make main.rkt
+}
+
+src_install() {
+	mkdir -pv "${D}/usr/share/racket/pkgs/libtoxcore-racket"
+	cp -Rv * "${D}/usr/share/racket/pkgs/libtoxcore-racket/"
+}
+
+pkg_postinst() {
+	raco link -i "/usr/src/racket/pkgs/libtoxcore-racket"
+}
+
+pkg_prerm() {
+	raco link -ir "/usr/src/racket/pkgs/libtoxcore-racket"
+}

--- a/dev-scheme/libtoxcore-racket/metadata.xml
+++ b/dev-scheme/libtoxcore-racket/metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer>
+		<email>maintainer-wanted@gentoo.org</email>
+	</maintainer>
+</pkgmetadata>

--- a/net-im/blight/blight-9999.ebuild
+++ b/net-im/blight/blight-9999.ebuild
@@ -15,10 +15,10 @@ SLOT="0"
 
 RDEPEND="net-libs/tox
 	>=dev-db/sqlite-3.8.6
-	>=dev-scheme/racket-6.0.1[X]"
+	>=dev-scheme/racket-6.0.1[X]
+    dev-scheme/libtoxcore-racket"
 
 src_prepare() {
-	raco pkg install --no-setup github://github.com/lehitoskin/libtoxcore-racket/master
 	epatch "$FILESDIR/${P}.patch"
 	epatch_user
 }


### PR DESCRIPTION
libtoxcore-racket is now in its own dev-scheme/libtoxcore-racket ebuild.
