### PR TITLE
Make tox bootstrap daemon use the daemon instead

### DIFF
--- a/net-libs/tox/files/confd
+++ b/net-libs/tox/files/confd
@@ -1,7 +1,2 @@
-# [--ipv4|--ipv6]
-cmdline=""
-
-# open node
-ip=""
-port=""
-key=""
+TOX_GROUP=tox
+TOX_USER=tox

--- a/net-libs/tox/files/initd
+++ b/net-libs/tox/files/initd
@@ -1,8 +1,7 @@
 #!/sbin/runscript
 
-PIDFILE=/run/tox-dht-bootstrap.pid
-LOGDIR=/var/log/tox-dht-bootstrap
-RUNDIR=/var/lib/tox-dht-bootstrap
+PIDDIR=/run/tox-dht-bootstrap
+PIDFILE="${PIDDIR}"/tox-dht-bootstrap.pid
 
 depend() {
 	need net
@@ -11,16 +10,13 @@ depend() {
 start() {
 	ebegin "Starting tox-dht-bootstrap daemon"
 
-	[ -d "${LOGDIR}" ] || mkdir -p "${LOGDIR}"
-	[ -d "${RUNDIR}" ] || mkdir -p "${RUNDIR}"
-	chown -R nobody:nobody "${LOGDIR}" "${RUNDIR}"
+	[ -d "${PIDDIR}" ] || mkdir -p "${PIDDIR}"
+	chown -R ${TOX_USER}:${TOX_GROUP} "${PIDDIR}"
 
 	start-stop-daemon --start \
-		--pidfile "${PIDFILE}" --make-pidfile --background \
-		--stdout "${LOGDIR}/stdout" --stderr "${LOGDIR}/stderr" \
-		--chdir "${RUNDIR}" \
-		--user=nobody --group=nobody \
-		--exec /usr/bin/DHT_bootstrap
+		--pidfile "${PIDFILE}" \
+		--user=${TOX_USER} --group=${TOX_GROUP} \
+		--exec /usr/bin/tox-bootstrapd -- /etc/tox-bootstrapd.conf
 
 	eend $?
 }

--- a/net-libs/tox/files/tox-bootstrapd.conf
+++ b/net-libs/tox/files/tox-bootstrapd.conf
@@ -1,0 +1,93 @@
+// Tox DHT bootstrap daemon configuration file.
+
+// Listening port (UDP).
+port = 33445
+
+// A key file is like a password, so keep it where no one can read it.
+// If there is no key file, a new one will be generated.
+// The daemon should have permission to read/write it.
+keys_file_path = "/var/lib/tox-dht-bootstrap/key"
+
+// The PID file written to by the daemon.
+// Make sure that the user that daemon runs as has permissions to write to the
+// PID file.
+pid_file_path = "/run/tox-dht-bootstrap/tox-dht-bootstrap.pid"
+
+// Enable IPv6.
+enable_ipv6 = true
+
+// Fallback to IPv4 in case IPv6 fails.
+enable_ipv4_fallback = true
+
+// Automatically bootstrap with nodes on local area network.
+enable_lan_discovery = false
+
+enable_tcp_relay = true
+
+// Tox uses 3389 and 33445 ports by default, so it's highly encouraged to keep
+// them. Tox also uses port 443, but this is not enabled here by default, as it
+// is usually reserved for https.
+tcp_relay_ports = [3389, 33445]
+
+// Reply to MOTD (Message Of The Day) requests.
+enable_motd = true
+
+// Just a message that is sent when someone requests MOTD.
+// Put anything you want, but note that it will be trimmed to fit into 255 bytes.
+motd = "tox-bootstrapd"
+
+// Any number of nodes the daemon will bootstrap itself off.
+//
+// Remember to replace the provided example with your own node list.
+// There is a maintained list of bootstrap nodes on Tox's wiki, if you need it
+// (http://wiki.tox.im/Nodes).
+//
+// You may leave the list empty or remove "bootstrap_nodes" completely,
+// in both cases this will be interpreted as if you don't want to bootstrap
+// from anyone.
+//
+// address = any ipv4 or ipv6 address and also any US-ASCII domain name.
+bootstrap_nodes = (
+  {   
+    // NikolaiToryzin - US
+    address = "192.254.75.102"
+    port = 33445
+    public_key = "951C88B7E75C867418ACDB5D273821372BB5BD652740BCDF623A4FA293E75D2F"
+  },
+  { 
+    // Proplex - US
+    address = "107.161.17.51"
+    port = 33445
+    public_key = "7BE3951B97CA4B9ECDDA768E8C52BA19E9E2690AB584787BF4C90E04DBB75111"
+  },
+  { 
+    // SonOfRa - DE
+    address = "144.76.60.215"
+    port = 33445
+    public_key = "04119E835DF3E78BACF0F84235B300546AF8B936F035185E2A8E9E0A67C8924F"
+  },
+  { 
+    // Astonex - FR
+    address = "37.59.102.176"
+    port = 33445
+    public_key = "B98A2CEAA6C6A2FADC2C3632D284318B60FE5375CCB41EFA081AB67F500C1B0B"
+  },
+  { 
+    // SylvieLorxu - NL
+    address = "178.21.112.187"
+    port = 33445
+    public_key = "4B2C19E924972CB9B57732FB172F8A8604DE13EEDA2A6234E348983344B23057"
+  },
+  { 
+    // aitjcize  - JP
+    address = "54.199.139.199"
+    port = 33445
+    public_key = "7F9C31FE850E97CEFD4C4591DF93FC757C7C12549DDD55F8EEAECC34FE76C029"
+  },
+  { 
+    // NikolaiToryzin - CH
+    address = "31.7.57.236"
+    port = 443
+    public_key = "2A4B50D1D525DA2E669592A20C327B5FAD6C7E5962DC69296F9FEC77C4436E4E"
+  }
+)

--- a/net-libs/tox/tox-9999.ebuild
+++ b/net-libs/tox/tox-9999.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=5
 
-inherit autotools eutils git-2
+inherit autotools eutils git-2 user
 
 DESCRIPTION="Encrypted P2P, messenging, and audio/video calling platform"
 HOMEPAGE="https://tox.im"
@@ -68,6 +68,13 @@ src_configure() {
 src_install() {
 	default
 	use daemon && { newinitd "${FILESDIR}"/initd tox-dht-daemon
-		newconfd "${FILESDIR}"/confd tox-dht-daemon ; }
+		newconfd "${FILESDIR}"/confd tox-dht-daemon
+		insinto /etc
+		doins "${FILESDIR}"/tox-bootstrapd.conf ; }
 	prune_libtool_files
+}
+
+pkg_postinst() {
+	use daemon && {	enewgroup ${PN}
+		enewuser ${PN} -1 -1 -1 ${PN} ; }
 }


### PR DESCRIPTION
It is actually configurable. The name etc. stays the same, however there is a small problem with backwards compatibility, namely the pidfile.

The pidfile used to be created by OpenRC, and written with root privileges. This caused a move to a dedicated directory. If the service is running while being upgraded, a restart will not function properly, and the process must be manually shut down in order to start the service again with its init script.

Also creates a dedicated user to run the daemon as (can be configured in
/etc/conf.d/tox-bootstrap-daemon)
