### PR TITLE
raco link needs to be in postinst

### DIFF
--- a/dev-scheme/libtoxcore-racket/libtoxcore-racket-9999.ebuild
+++ b/dev-scheme/libtoxcore-racket/libtoxcore-racket-9999.ebuild
@@ -28,6 +28,10 @@ src_install() {
 	emake DESTDIR="${D}/usr" install
 }
 
+pkg_postinst() {
+    raco link -i "/usr/share/racket/pkgs/libtoxcore-racket"
+}
+
 pkg_prerm() {
 	raco link -ir "/usr/share/racket/pkgs/libtoxcore-racket"
 }


### PR DESCRIPTION
If compiling from Makefile, it'll try to do some shenanigans with the sandbox that doesn't fly.
