### PR TITLE
[net-im/qtox] add qt xcb dependency

### DIFF
--- a/net-im/qtox/qtox-9999.ebuild
+++ b/net-im/qtox/qtox-9999.ebuild
@@ -21,7 +21,7 @@ DEPEND="
 	dev-qt/linguist-tools:5
 	dev-qt/qtconcurrent:5
 	dev-qt/qtcore:5
-	dev-qt/qtgui:5[gif,jpeg,png]
+	dev-qt/qtgui:5[gif,jpeg,png,xcb]
 	dev-qt/qtnetwork:5
 	dev-qt/qtopengl:5
 	dev-qt/qtsql:5


### PR DESCRIPTION
The qtox application depends on the qt xcb platform plugin. This
dependency was missing from the ebuild.

Closes Tox/gentoo-overlay-tox#71
