### PR TITLE
Update Homepage

### DIFF
--- a/net-im/toxic/toxic-9999.ebuild
+++ b/net-im/toxic/toxic-9999.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 inherit autotools eutils git-2 toolchain-funcs
 
 DESCRIPTION="CLI Frontend for Tox"
-HOMEPAGE="http://wiki.tox.im/Toxic"
+HOMEPAGE="https://wiki.tox.chat/clients/toxic"
 SRC_URI=""
 EGIT_REPO_URI="git://github.com/Tox/toxic
 	https://github.com/Tox/toxic"

--- a/net-libs/tox/files/tox-bootstrapd.conf
+++ b/net-libs/tox/files/tox-bootstrapd.conf
@@ -39,7 +39,7 @@ motd = "tox-bootstrapd"
 //
 // Remember to replace the provided example with your own node list.
 // There is a maintained list of bootstrap nodes on Tox's wiki, if you need it
-// (http://wiki.tox.im/Nodes).
+// (https://wiki.tox.chat/users/nodes).
 //
 // You may leave the list empty or remove "bootstrap_nodes" completely,
 // in both cases this will be interpreted as if you don't want to bootstrap

--- a/net-libs/tox/tox-9999.ebuild
+++ b/net-libs/tox/tox-9999.ebuild
@@ -7,7 +7,7 @@ EAPI=5
 inherit autotools eutils git-2 user systemd
 
 DESCRIPTION="Encrypted P2P, messenging, and audio/video calling platform"
-HOMEPAGE="https://tox.im"
+HOMEPAGE="https://tox.chat"
 SRC_URI=""
 EGIT_REPO_URI="git://github.com/irungentoo/toxcore.git
 	https://github.com/irungentoo/toxcore.git"


### PR DESCRIPTION
Removed links pointing to tox.im that I could find (excluding e-mail addresses).

The repository website should probably be changed as well (Official Gentoo overlay for Toxcore, Tox clients, and Tox related projects https://tox.im).
