### PR TITLE
Add https:// repository URIs for GitHub ebuilds

### DIFF
--- a/dev-libs/flatbuffers/flatbuffers-9999.ebuild
+++ b/dev-libs/flatbuffers/flatbuffers-9999.ebuild
@@ -9,7 +9,8 @@ inherit eutils git-2 cmake-utils
 DESCRIPTION="Memory Efficient Serialization Library"
 HOMEPAGE="http://google.github.io/flatbuffers/"
 SRC_URI=""
-EGIT_REPO_URI="git://github.com/google/flatbuffers.git"
+EGIT_REPO_URI="git://github.com/google/flatbuffers.git
+	https://github.com/google/flatbuffers.git"
 
 LICENSE="Apache-2.0"
 SLOT="0"

--- a/net-im/gtox/gtox-9999.ebuild
+++ b/net-im/gtox/gtox-9999.ebuild
@@ -9,7 +9,8 @@ inherit eutils git-2 cmake-utils
 DESCRIPTION="A GTK3 Tox-Client"
 HOMEPAGE="https://github.com/kokutoru/gtox"
 SRC_URI=""
-EGIT_REPO_URI="git://github.com/kokutoru/gtox.git"
+EGIT_REPO_URI="git://github.com/kokutoru/gtox.git
+	https://github.com/kokutoru/gtox.git"
 
 LICENSE="GPL-3"
 SLOT="0"

--- a/net-im/qtox/qtox-9999.ebuild
+++ b/net-im/qtox/qtox-9999.ebuild
@@ -9,7 +9,8 @@ inherit eutils qmake-utils git-2
 DESCRIPTION="GUI for net-libs/tox using QT5 with code similarities to net-im/tox-gui-qt"
 HOMEPAGE="https://github.com/tux3/qtox"
 SRC_URI=""
-EGIT_REPO_URI="git://github.com/tux3/qtox.git"
+EGIT_REPO_URI="git://github.com/tux3/qtox.git
+	https://github.com/tux3/qtox.git"
 
 LICENSE="GPL-3"
 SLOT="0"

--- a/net-misc/toxbot/toxbot-9999.ebuild
+++ b/net-misc/toxbot/toxbot-9999.ebuild
@@ -9,7 +9,8 @@ inherit eutils git-2 toolchain-funcs
 DESCRIPTION="Tox groupchats bot"
 HOMEPAGE="https://github.com/JFreegman/ToxBot"
 SRC_URI=""
-EGIT_REPO_URI="git://github.com/JFreegman/ToxBot.git"
+EGIT_REPO_URI="git://github.com/JFreegman/ToxBot.git
+	https://github.com/JFreegman/ToxBot.git"
 
 LICENSE="GPL-3"
 SLOT="0"

--- a/net-misc/toxvpn/toxvpn-9999.ebuild
+++ b/net-misc/toxvpn/toxvpn-9999.ebuild
@@ -9,7 +9,8 @@ inherit cmake-utils eutils git-2
 DESCRIPTION="toxvpn allows one to make tunneled point to point connections over Tox"
 HOMEPAGE="https://github.com/cleverca22/toxvpn"
 SRC_URI=""
-EGIT_REPO_URI="git://github.com/cleverca22/toxvpn.git"
+EGIT_REPO_URI="git://github.com/cleverca22/toxvpn.git
+	https://github.com/cleverca22/toxvpn.git"
 
 LICENSE="GPL-3"
 SLOT="0"


### PR DESCRIPTION
Useful when e.g. a firewall blocks the git protocol.
